### PR TITLE
update jobtasksview

### DIFF
--- a/config_creator/core/views.py
+++ b/config_creator/core/views.py
@@ -388,13 +388,16 @@ def jobdownload(request, pk):
 def jobtasksview(request, job_id):
     job = Job.objects.select_related().get(id=job_id)
     if job.get_property_object():
-        properties = job.get_property_object().pprint()
+        job_property = job.get_property_object()
+        properties = job_property.pprint()
+        job_property_id = job_property.id
     else:
         properties = {}
+        job_property_id = None
     context = {
         "job": job,
         "properties": [{k: properties.get(k)} for k in properties.keys()],
-        "property_id": properties.get("id"),
+        "property_id": job_property_id,
         "tasks": JobTask.objects.select_related().filter(job=job),
     }
     return render(


### PR DESCRIPTION
job.get_property_object().pprint() didn't contain id field. Update method to call object and set id variable

<!-- Thanks for sending a pull request! Please add matching labels from any issues closed -->

# What does this implement/fix? Explain your changes
Fix but #125.  Method pulled property and captured details using `pprint` method.  This did not include id value.

Updated method to set property object as variable allowing id to be captured.

# Does this close any currently open issues?
Closes #125 

# Any other comments?
None
